### PR TITLE
fix: use 'pnpm exec tsc' instead of 'npx tsc' to avoid wrong package …

### DIFF
--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -12,8 +12,8 @@
   },
   "scripts": {
     "start": "node dist/bin.js",
-    "dev": "npx tsc -w",
-    "build": "npx tsc",
+    "dev": "pnpm exec tsc -w",
+    "build": "pnpm exec tsc",
     "prepack": "pnpm build",
     "test": "jest"
   },


### PR DESCRIPTION
…installation

In CI environment, 'npx tsc' was installing wrong 'tsc@2.0.4' package instead of using typescript from devDependencies, causing build failure during prepack step when publishing.

Root cause:
- npx searches for executables in unexpected order
- In CI, it finds and installs a different 'tsc' package (v2.0.4)
- This breaks the build during 'pnpm publish' prepack lifecycle

Solution:
- Use 'pnpm exec tsc' which correctly uses typescript from node_modules
- Applied to both 'build' and 'dev' scripts for consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)